### PR TITLE
Fix a bug when using defmt feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1106,7 +1106,7 @@ where
                 }
                 Ok(_n) => {
                     #[cfg(feature = "defmt")]
-                    info!("Cleared {} bytes: {:?}", n, &buffer[.._n]);
+                    info!("Cleared {} bytes: {:?}", _n, &buffer[.._n]);
                     // Short delay and try again
                     self.delay.delay_ms(10).await;
                 }


### PR DESCRIPTION
Thanks for this library! I noticed that it currently doesn't compile when the `defmt` is turned on due to a small typo. This PR fixes that. The error I got otherwise:

```
     |
1107 |                 Ok(_n) => {
     |                    -- `_n` defined here
1108 |                     #[cfg(feature = "defmt")]
1109 |                     info!("Cleared {} bytes: {:?}", n, &buffer[.._n]);
     |                                                     ^
     |
help: the leading underscore in `_n` marks it as unused, consider renaming it to `n`
     |
1107 -                 Ok(_n) => {
1107 +                 Ok(n) => {
     |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `dfplayer-async` (lib) due to 1 previous error
```