### PR TITLE
Refactor DfPlayer initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dfplayer-async"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "A simple embedded-hal-async driver for the DFPlayer mini MP3 module."
 keywords = ["no-std", "embedded-hal-async", "mp3", "dfplayer", "driver"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dfplayer-async = "0.3.0"
+dfplayer-async = "0.5.0"
 ```
 
 ## Examples

--- a/examples/src/basic.rs
+++ b/examples/src/basic.rs
@@ -21,7 +21,7 @@
 #![no_std]
 #![no_main]
 
-use defmt::{error, info, Debug2Format};
+use defmt::{Debug2Format, error, info};
 use dfplayer_async::{DfPlayer, Equalizer, TimeSource};
 use embassy_executor::Spawner;
 use embassy_rp::{
@@ -104,7 +104,7 @@ async fn main(_spawner: Spawner) {
     }
 
     // Create the DFPlayer Mini instance, handing in the UART instance and the TimeSource implementation as well as the other parameters.
-    let mut dfplayer = match DfPlayer::try_new(
+    let mut dfplayer = match DfPlayer::new(
         &mut uart,
         feedback_enable,
         timeout_ms,

--- a/examples/src/query.rs
+++ b/examples/src/query.rs
@@ -21,7 +21,7 @@
 #![no_std]
 #![no_main]
 
-use defmt::{error, info, Debug2Format};
+use defmt::{Debug2Format, error, info};
 use dfplayer_async::{DfPlayer, Equalizer, TimeSource};
 use embassy_executor::Spawner;
 use embassy_rp::{
@@ -103,7 +103,7 @@ async fn main(_spawner: Spawner) {
     }
 
     // Create the DFPlayer Mini instance, handing in the UART instance and the TimeSource implementation as well as the other parameters.
-    let mut dfplayer = match DfPlayer::try_new(
+    let mut dfplayer = match DfPlayer::new(
         &mut uart,
         feedback_enable,
         timeout_ms,

--- a/examples/src/sleep.rs
+++ b/examples/src/sleep.rs
@@ -21,7 +21,7 @@
 #![no_std]
 #![no_main]
 
-use defmt::{error, info, Debug2Format};
+use defmt::{Debug2Format, error, info};
 use dfplayer_async::{DfPlayer, TimeSource};
 use embassy_executor::Spawner;
 use embassy_rp::{
@@ -101,7 +101,7 @@ async fn main(_spawner: Spawner) {
     }
 
     // Create the DFPlayer Mini instance
-    let mut dfplayer = match DfPlayer::try_new(
+    let mut dfplayer = match DfPlayer::new(
         &mut uart,
         feedback_enable,
         timeout_ms,
@@ -163,7 +163,6 @@ async fn main(_spawner: Spawner) {
         Ok(_) => info!("Wake up command sent successfully"),
         Err(e) => error!("Failed to wake up device: {}", Debug2Format(&e)),
     }
-
 
     // Wait a moment for the device to fully wake up
     Timer::after(Duration::from_secs(1)).await;


### PR DESCRIPTION
This pull request updates the `dfplayer-async` crate to version 0.5.0 and refines the initialization and buffer clearing logic for the DFPlayer Mini driver. The changes improve logging, simplify the buffer clearing process, and update usage examples and documentation to reflect the new API.

**API and Documentation Updates:**

* Renamed the main constructor from `DfPlayer::try_new` to `DfPlayer::new` across the codebase, including documentation and all example files, to clarify initialization and align with Rust conventions. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L476-R485) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L35-R35) Fdcf211fL104R104, [[3]](diffhunk://#diff-1e08e8f5779c397f0a34f3308837a4fbc56ae41bd31b91feb7f4e70c51d2c5a6L106-R106) [[4]](diffhunk://#diff-cf74818bec93f69e5cf4cbfe3dd5f36ca791e414e2ed9b0aa36f28a1b05c4b71L104-R104)
* Updated crate version to `0.5.0` in `Cargo.toml` and usage instructions in `README.md`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35)

**Initialization and Logging Improvements:**

* Added detailed `defmt` logging throughout the initialization process in `DfPlayer::new`, including buffer clearing, reset, source selection, and volume setup, making debugging and device startup status clearer. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L476-R485) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R501-R534) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L533-R560) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R571-R588) [[5]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L573-R599)

**Buffer Clearing Logic Simplification:**

* Refactored `clear_receive_buffer` to use a simpler, single-read approach based on data availability, removing repeated attempts and timeouts, and added more granular logging for each step.

**Minor Code and Example Cleanups:**

* Standardized import ordering in example files for consistency. [[1]](diffhunk://#diff-31201c627903cbbbf1a87778d6281f684e82dff2153613366e4ccd2e704a6dadL24-R24) [[2]](diffhunk://#diff-1e08e8f5779c397f0a34f3308837a4fbc56ae41bd31b91feb7f4e70c51d2c5a6L24-R24) [[3]](diffhunk://#diff-cf74818bec93f69e5cf4cbfe3dd5f36ca791e414e2ed9b0aa36f28a1b05c4b71L24-R24)
* Removed an unnecessary blank line in `examples/src/sleep.rs`.
* Minor formatting fix for the `PlayLoopFolder` command invocation.